### PR TITLE
Don't require global electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,4 @@ Electron tool for running layered neural network experiments
 1. Clone the repo
 2. Run `npm install`
 3. (Optional) download the MNIST and Omniglot datasets with `npm run fetch-mnist` and `npm run fetch-omniglot`
-4. Run an experiment using `electron . <configname>`. E.g. `electron . samples/matching_pursuit`
-
+4. Run an experiment using `npm start <configname>`. E.g. `npm start samples/matching_pursuit`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "fetch-mnist": "bin/fetch-mnist.js",
-    "fetch-omniglot": "bin/fetch-omniglot.js"
+    "fetch-omniglot": "bin/fetch-omniglot.js",
+    "start": "electron . "
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Readme was missing `npm install -g electron`
This change makes it so they don't require it. 